### PR TITLE
Accept query params in the artist_setlist method.

### DIFF
--- a/lib/WebService/SetlistFM.pm
+++ b/lib/WebService/SetlistFM.pm
@@ -91,7 +91,8 @@ sub venue {
 sub artist_setlists {
     my $self = shift;
     my $mbid = shift;
-    return $self->request("artist/$mbid/setlists.json");
+    my $query_param = shift;
+    return $self->request("artist/$mbid/setlists.json", $query_param);
 } 
 
 sub setlist_lastfm {


### PR DESCRIPTION
You only have a `$query_params` argument on a few methods, but many more of them could use it (for example, for paging of results).

This commit adds support for `$query_params` to `artist_setlist()` - as that was the method I was working with when I discovered this problem. I may send more pull requests with more fixes later.
